### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["bam", "htslib", "bioinformatics", "genomic"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-htslib = "0.44.1"
-rand = "0.8.5"
-derive_builder = "0.12.0"
+rust-htslib = "0.51.0"
+rand = "0.9.2"
+derive_builder = "0.20.2"
 tempfile = "3.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ impl BamBuilder {
     /// Generate a random sequence of bases of length readLength.
     fn random_bases(&mut self) -> String {
         (0..self.read_length)
-            .map(|_| DEFAULT_BASES[self.rng.gen_range(0..DEFAULT_BASES.len())])
+            .map(|_| DEFAULT_BASES[self.rng.random_range(0..DEFAULT_BASES.len())])
             .collect::<String>()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,8 @@ impl BamBuilder {
         r1.set_first_in_template();
         if pair_spec.unmapped1 {
             r1.set_unmapped();
+        } else {
+            r1.unset_unmapped();
         }
 
         let mut r2 = Record::new();
@@ -369,6 +371,8 @@ impl BamBuilder {
         r2.set_last_in_template();
         if pair_spec.unmapped2 {
             r2.set_unmapped();
+        } else {
+            r2.unset_unmapped();
         }
         r1.push_aux("RG".as_bytes(), Aux::String(self.read_group_id.0.as_str()))
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,14 +398,14 @@ impl BamBuilder {
             if rec2.is_reverse() {
                 rec1.set_mate_reverse()
             }
-            rec1.push_aux(b"MQ", Aux::Char(rec2.mapq())).unwrap();
+            rec1.push_aux(b"MQ", Aux::U8(rec2.mapq())).unwrap();
 
             rec2.set_mtid(rec1.tid());
             rec2.set_mpos(rec1.pos());
             if rec1.is_reverse() {
                 rec2.set_mate_reverse()
             }
-            rec2.push_aux(b"MQ", Aux::Char(rec1.mapq())).unwrap();
+            rec2.push_aux(b"MQ", Aux::U8(rec1.mapq())).unwrap();
 
             if set_mate_cigar {
                 rec1.push_aux(b"MC", Aux::String(rec2.cigar().to_string().as_str()))
@@ -450,7 +450,7 @@ impl BamBuilder {
             rec1.set_mtid(rec2.tid());
             rec1.set_mpos(rec2.pos());
             rec1.set_insert_size(0);
-            rec1.push_aux(b"MQ", Aux::Char(rec2.mapq())).unwrap();
+            rec1.push_aux(b"MQ", Aux::U8(rec2.mapq())).unwrap();
             if set_mate_cigar {
                 rec1.push_aux(b"MC", Aux::String(rec2.cigar().to_string().as_str()))
                     .unwrap();
@@ -474,7 +474,7 @@ impl BamBuilder {
             rec2.set_mtid(rec1.tid());
             rec2.set_mpos(rec1.pos());
             rec2.set_insert_size(0);
-            rec2.push_aux(b"MQ", Aux::Char(rec1.mapq())).unwrap();
+            rec2.push_aux(b"MQ", Aux::U8(rec1.mapq())).unwrap();
             if set_mate_cigar {
                 rec2.push_aux(b"MC", Aux::String(rec1.cigar().to_string().as_str()))
                     .unwrap();
@@ -656,7 +656,7 @@ mod tests {
         assert!(builder.records[0].is_mate_reverse());
         assert!(!builder.records[1].is_mate_reverse());
         // Test mate tags set
-        assert_eq!(builder.records[0].aux(b"MQ").unwrap(), Aux::Char(60));
+        assert_eq!(builder.records[0].aux(b"MQ").unwrap(), Aux::U8(60));
         assert_eq!(builder.records[0].aux(b"MC").unwrap(), Aux::String("100M"));
         // Check for read group set
         assert_eq!(builder.records[0].aux(b"RG").unwrap(), Aux::String("A"));
@@ -713,7 +713,7 @@ mod tests {
         assert!(!builder.records[1].is_mate_reverse());
         // Test mate tags set
         assert_eq!(builder.records[0].aux(b"MQ").ok(), None);
-        assert_eq!(builder.records[1].aux(b"MQ").unwrap(), Aux::Char(60));
+        assert_eq!(builder.records[1].aux(b"MQ").unwrap(), Aux::U8(60));
         assert_eq!(builder.records[0].aux(b"MC").ok(), None);
         assert_eq!(builder.records[1].aux(b"MC").unwrap(), Aux::String("100M"));
         // Check for read group set


### PR DESCRIPTION
My newish version of rustc couldn't build the older rust_htslib dependency. So this does two things:
1. Bump dependency version to the latest.
2. Change one deprecated function invocation to the new name.

With these fixes I was able to build.